### PR TITLE
Feat/bump juce 8.0.4

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ juce_add_plugin(ExamplePlugin
     # VERSION ...                                     # Set this if the plugin version is different to the project version
     # ICON_BIG ""   # ICON_* arguments specify a path to an image file to use as an icon for the Standalone
     #   ICON_SMALL "${CMAKE_SOURCE_DIR}/Assets/icon16.png " 
-    COMPANY_NAME "Tomoya Matsuura"                    # Specify the name of the plugin's author
+    COMPANY_NAME "TomoyaMatsuura"                    # Specify the name of the plugin's author
     COMPANY_COPYRIGHT "Tomoya Matsuura"
     COMPANY_WEBSITE "https://matsuuratomoya.com/"
     COMPANY_EMAIL "me@matsuuratomoya.com"


### PR DESCRIPTION
This PR updates juce version from 7.0.3 to 8.0.4 with suppressing warning after updating.
Confirmed all the builds for Visual Studio are available.